### PR TITLE
Add Windows 10 style window titlebar

### DIFF
--- a/components/Settings.js
+++ b/components/Settings.js
@@ -185,7 +185,7 @@ class Settings extends React.Component {
               top: 44px;
               left: 0;
               border: 1px solid ${COLORS.SECONDARY};
-              width: 184px;
+              width: 242px;
               border-radius: 3px;
               background: ${COLORS.BLACK};
             }

--- a/components/ThemeSelect.js
+++ b/components/ThemeSelect.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { None, BW, Sharp } from './svg/WindowThemes'
+import { None, BW, Sharp, Win } from './svg/WindowThemes'
 import { COLORS } from '../lib/constants'
 
-const WINDOW_THEMES_MAP = { none: None, sharp: Sharp, bw: BW }
+const WINDOW_THEMES_MAP = { none: None, sharp: Sharp, bw: BW, win: Win }
 export const WINDOW_THEMES = Object.keys(WINDOW_THEMES_MAP)
 
 class ThemeSelect extends React.Component {

--- a/components/WindowControls.js
+++ b/components/WindowControls.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import CopyButton from './CopyButton'
 import { COLORS } from '../lib/constants'
-import { Controls, ControlsBW } from './svg/Controls'
+import { Controls, ControlsBW, ControlsWin } from './svg/Controls'
 import CopySVG from './svg/Copy'
 import CheckMark from './svg/Checkmark'
 
@@ -36,7 +36,7 @@ function renderCopyButton({ copied }) {
 
 export default ({ titleBar, theme, handleTitleBarChange, copyable, code }) => (
   <div className="window-controls">
-    {theme === 'bw' ? <ControlsBW /> : <Controls />}
+    {theme === 'bw' ? <ControlsBW /> : theme === 'win' ? <ControlsWin /> : <Controls />}
     <div className="window-title-container">
       <input
         aria-label="Image Title"

--- a/components/svg/Controls.js
+++ b/components/svg/Controls.js
@@ -19,3 +19,14 @@ export const ControlsBW = () => (
     </g>
   </svg>
 )
+
+export const ControlsWin = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="120" height="30" viewBox="0 0 120 30">
+    <g fill="none" fillRule="evenodd" transform="translate(1 1)">
+      <line x1="0.5" y1="15.5" x2="9.5" y2="15.5" stroke="#ffffff" strokeWidth="1" />
+      <rect x="45.5" y="10.5" width="9" height="9" stroke="#ffffff" strokeWidth="1" />
+      <line x1="91.5" y1="10.5" x2="100.5" y2="19.5" stroke="#ffffff" strokeWidth="1" />
+      <line x1="91.5" y1="19.5" x2="100.5" y2="10.5" stroke="#ffffff" strokeWidth="1" />
+    </g>
+  </svg>
+)

--- a/components/svg/WindowThemes.js
+++ b/components/svg/WindowThemes.js
@@ -111,3 +111,35 @@ export const None = () => (
     </g>
   </svg>
 )
+
+export const Win = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="50"
+    height="50"
+    viewBox="0 0 81 81"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+  >
+    <defs>
+      <rect id="a1" width="81" height="81" rx="3" />
+    </defs>
+    <g fill="none" fillRule="evenodd">
+      <mask id="b1" fill="white">
+        <use xlinkHref="#a1" />
+      </mask>
+      <use fill="#616161" xlinkHref="#a1" />
+      <g transform="translate(0 32)" mask="url(#b1)">
+        <path
+          fill="#000000"
+          fillRule="nonzero"
+          d="M66.0458013,46.1092762 C66.0458013,48.3193105 64.2622787,50.1077029 62.050805,50.1077029 L0.174089069,50.1077029 L0.174089069,6.16868499 C0.174089069,0.174657534 0.174089069,0.174657534 0.174089069,0.174657534 L66.0458013,0.174657534 L66.0458013,46.1092762 Z"
+        />
+        <g transform="translate(5 12.5)">
+          <rect x="0" y="0" width="8" height="8" stroke="#ffffff" strokeWidth="1" />
+          <line x1="37" y1="0" x2="45" y2="8" stroke="#ffffff" strokeWidth="1" />
+          <line x1="37" y1="8" x2="45" y2="0" stroke="#ffffff" strokeWidth="1" />
+        </g>
+      </g>
+    </g>
+  </svg>
+)


### PR DESCRIPTION
I have added the basic SVGs for this, added to the settings menu, and created the theme setting. I'm not sure if I did it properly, it took a lot of guesswork since I've never used Node or React before. It works, with a few caveats.

- The icon in the settings menu looks terrible. I couldn't figure out how to make it, because I don't understand very well how SVG viewboxes work in conjunction with width and height.

- The titlebar buttons are on the left. I got them on the right in the correct position using `text-align: right; right: 1px;` in the browser developer tools on the `.window-controls` class, but could not figure out hoe to make the changes in the code itself. My attempt in the file `components/Carbon.js` can be seen below, added somewhere around line 219.


```css
.container :global(.window-theme__sharp > .CodeMirror),
.container :global(.window-theme__win > .CodeMirror) {
  border-radius: 0px;
}

.container :global(.window-theme__bw > .CodeMirror) {
  border: 2px solid ${COLORS.SECONDARY};
}

.container :global(.window-theme__win + .window-controls) {
  text-align: right;
  right: 1px; /* Necessary to match Windows titlebar exactly. */
}
```

![image](https://user-images.githubusercontent.com/12502988/45924339-5be52480-beb2-11e8-9872-e4ca3cd4b9b9.png)


With the above CSS, the style is pixel-perfect to match Windows. Unfortunately the positioning is not.

This pull request needs work, but I'm not sure how to do it myself. I hope this addition is sufficient for the maintainers to work off of.