### PR TITLE
Add a11y-dark theme

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -50,6 +50,25 @@ export const THEMES = [
     }
   },
   {
+    id: 'a11y-dark',
+    name: 'a11y-dark',
+    highlights: {
+      background: '#2b2b2b',
+      text: '#f8f8f2',
+      variable: '#00e0e0',
+      attribute: '#abe338',
+      definition: '#ffd700',
+      keyword: '#ffa07a',
+      operator: '#f8f8f2',
+      property: '#abe338',
+      number: '#dcc6e0',
+      string: '#ffd700',
+      comment: '#d4d0ab',
+      meta: '#d4d0ab',
+      tag: '#dcc6e0'
+    }
+  },
+  {
     id: 'blackboard',
     name: 'Blackboard',
     highlights: {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -51,7 +51,7 @@ export const THEMES = [
   },
   {
     id: 'a11y-dark',
-    name: 'a11y-dark',
+    name: 'A11y Dark',
     highlights: {
       background: '#2b2b2b',
       text: '#f8f8f2',
@@ -488,25 +488,6 @@ export const THEMES = [
       comment: '#6d77b3',
       meta: '#ff8b39',
       tag: '#f92aad'
-    }
-  },
-  {
-    id: 'tomorrow-night-bright',
-    name: 'Tomorrow Night',
-    highlights: {
-      background: '#000000',
-      text: '#eaeaea',
-      variable: '#7aa6da',
-      attribute: '#99cc99',
-      definition: '#e78c45',
-      keyword: '#d54e53',
-      operator: '#fff',
-      property: '#99cc99',
-      number: '#a16a94',
-      string: '#e7c547',
-      comment: '#d27b53',
-      meta: '#555',
-      tag: '#d54e53'
     }
   },
   {


### PR DESCRIPTION
This PR adds my [a11y-dark theme](https://github.com/ericwbailey/a11y-syntax-highlighting#a11y-dark). It is a syntax highlighting theme that uses all WCAG AAA compliant values for color contrast.

<img width="938" alt="Code in Carbon highlighted using the a11y-dark theme." src="https://user-images.githubusercontent.com/634191/66792539-32d17080-eec7-11e9-9df7-999f0f1fd6a4.png">

Thanks for considering it! Carbon's a really great app, and I'm excited to be able to contribute 🎉 