### PR TITLE
nef - Xcode Editor Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Check out these projects our awesome community has created:
 - [Vim `carbon-now-sh`](https://github.com/kristijanhusak/vim-carbon-now-sh) - Open up the selection in your current Vim/Neovim using function `CarbonNowSh()`
 - [Emacs `carbon-now-sh`](https://github.com/veelenga/carbon-now-sh.el) - Open up the selection in your current Emacs using interactive function `carbon-now-sh`
 - [Xcode `carbon-now-sh`](https://github.com/StevenMagdy/CarboNow4Xcode) - Open up your current selection in `carbon.now.sh`
+- [Xcode `nef`](https://github.com/bow-swift/nef-plugin) - This Xcode extension enables you to make a code selection and export it to a snippet without any other extra action. Available on [Mac AppStore](https://apps.apple.com/es/app/nef/id1479391704?l=en&mt=12)
 
 ##### Tools
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Check out these projects our awesome community has created:
 - [Vim `carbon-now-sh`](https://github.com/kristijanhusak/vim-carbon-now-sh) - Open up the selection in your current Vim/Neovim using function `CarbonNowSh()`
 - [Emacs `carbon-now-sh`](https://github.com/veelenga/carbon-now-sh.el) - Open up the selection in your current Emacs using interactive function `carbon-now-sh`
 - [Xcode `carbon-now-sh`](https://github.com/StevenMagdy/CarboNow4Xcode) - Open up your current selection in `carbon.now.sh`
-- [Xcode `nef`](https://github.com/bow-swift/nef-plugin) - This Xcode extension enables you to make a code selection and export it to a snippet without any other extra action. Available on [Mac AppStore](https://apps.apple.com/es/app/nef/id1479391704?l=en&mt=12)
+- [Xcode `nef`](https://github.com/bow-swift/nef-plugin) - This Xcode extension enables you to export a code selection as a Carbon snippet with a single action
 
 ##### Tools
 
@@ -315,4 +315,5 @@ Thanks goes out to all these wonderful people ([emoji key](https://github.com/ke
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Check out these projects our awesome community has created:
 - [Vim `carbon-now-sh`](https://github.com/kristijanhusak/vim-carbon-now-sh) - Open up the selection in your current Vim/Neovim using function `CarbonNowSh()`
 - [Emacs `carbon-now-sh`](https://github.com/veelenga/carbon-now-sh.el) - Open up the selection in your current Emacs using interactive function `carbon-now-sh`
 - [Xcode `carbon-now-sh`](https://github.com/StevenMagdy/CarboNow4Xcode) - Open up your current selection in `carbon.now.sh`
-- [Xcode `nef`](https://github.com/bow-swift/nef-plugin) - This Xcode extension enables you to export a code selection as a Carbon snippet with a single action
+- [Xcode `nef`](https://github.com/bow-swift/nef-plugin) - This Xcode extension enables you to export a code selection as a Carbon snippet in a single action
 
 ##### Tools
 


### PR DESCRIPTION
Repository: https://github.com/bow-swift/nef-plugin

This project provides an extension for Xcode to integrate some nef features directly in the IDE. Using the core of nef, you can export snippets from your code selection directly in Xcode.

![nef-plugin-action-export](https://user-images.githubusercontent.com/25568562/67399407-7fded200-f5ac-11e9-9b2e-8adf5e585797.png)
![Screenshot 2019-10-23 at 15 52 00](https://user-images.githubusercontent.com/25568562/67399863-24611400-f5ad-11e9-9e49-7dcf7dceaf26.png)

**Note** I think it could replace the old [Xcode extension](https://github.com/StevenMagdy/CarboNow4Xcode), but I let you to consideration ;)

