### PR TITLE
Display login button on all pages

### DIFF
--- a/components/EditorContainer.js
+++ b/components/EditorContainer.js
@@ -4,7 +4,6 @@ import { useAsyncCallback } from 'actionsack'
 
 import Editor from './Editor'
 import Toasts from './Toasts'
-import LoginButton from './LoginButton'
 import { useAPI } from './ApiContext'
 import { useAuth } from './AuthContext'
 
@@ -102,18 +101,6 @@ function EditorContainer(props) {
 
   return (
     <>
-      <div className="login-button-container">
-        <LoginButton />
-        <style jsx>
-          {`
-            .login-button-container {
-              position: absolute;
-              top: 1.4rem;
-              right: 1rem;
-            }
-          `}
-        </style>
-      </div>
       <Toasts toasts={toasts} />
       <Editor
         {...props}

--- a/components/LoginButton.js
+++ b/components/LoginButton.js
@@ -87,7 +87,7 @@ function LoginButton({ isVisible, toggleVisibility }) {
             height: 100%;
           }
           div :global(.profile-button) {
-            max-width: 142px;
+            max-width: 218px;
             min-height: 40px;
           }
           span {

--- a/components/Page.js
+++ b/components/Page.js
@@ -4,6 +4,7 @@ import Meta from './Meta'
 import Header from './Header'
 import Footer from './Footer'
 import Announcement from './Announcement'
+import LoginButton from './LoginButton'
 
 const COLUMN = `
   display: flex;
@@ -20,6 +21,9 @@ class Page extends React.Component {
         <AuthContext>
           <Announcement />
           <Header enableHeroText={enableHeroText} />
+          <div className="login-button-container">
+            <LoginButton />
+          </div>
           <div className="page">{children}</div>
         </AuthContext>
 
@@ -29,6 +33,11 @@ class Page extends React.Component {
           {`
             .main {
               ${flex ? COLUMN : ''}
+            }
+            .login-button-container {
+              position: absolute;
+              top: 1.4rem;
+              right: 1rem;
             }
             @media (min-width: 1024px) {
               .main {


### PR DESCRIPTION
## Description

This adds the Login/Account button to the top of all pages, including the account and snippets page. This makes transitions between pages look more natural as the button doesn't suddenly disappear. In addition, it adds the previously missing ability to sign out on the account/snippets page, which might be useful if the user discovers they're using the wrong account.

## Screenshots

|Before|After|
|------|-----|
|![image](https://user-images.githubusercontent.com/10191084/69664196-bc369f80-103c-11ea-9153-a663c5931b73.png)|![image](https://user-images.githubusercontent.com/10191084/69664169-ab862980-103c-11ea-9ea8-a434ac9a9ec7.png)|