### PR TITLE
Fixed first prefix always selected(hightlighted / cursor "not allowed")

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -218,7 +218,7 @@ class Editor extends React.Component {
 
   updateSetting(key, value) {
     this.updateState({ [key]: value })
-    if (Object.prototype.hasOwnProperty.call(DEFAULT_SETTINGS, key) && key !== 'preset') {
+    if (Object.prototype.hasOwnProperty.call(DEFAULT_SETTINGS, key)) {
       this.updateState({ preset: null })
     }
   }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1052,8 +1052,7 @@ export const DEFAULT_SETTINGS = {
   exportSize: '2x',
   watermark: false,
   squaredImage: false,
-  hiddenCharacters: false,
-  id: 'preset:4'
+  hiddenCharacters: false
 }
 
 export const DEFAULT_PRESETS = [

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1053,7 +1053,7 @@ export const DEFAULT_SETTINGS = {
   watermark: false,
   squaredImage: false,
   hiddenCharacters: false,
-  preset: 'preset:4'
+  id: 'preset:4'
 }
 
 export const DEFAULT_PRESETS = [


### PR DESCRIPTION
This pull request fixes the issue that when selecting other presets, the first preset remains highlighted with "not allowed" cursor event and cannot be selected.

Blue preset is clicked, but first grey preset is still highlighted and cannot be selected.
![Screenshot from 2020-01-04 09-00-09](https://user-images.githubusercontent.com/29286430/71769034-ccaa2780-2ed0-11ea-8237-161313b65d5d.png)

Preset selection fixed.
![Screenshot from 2020-01-04 08-59-24](https://user-images.githubusercontent.com/29286430/71769058-0bd87880-2ed1-11ea-8fad-efc41d7e0036.png)


In presets file, selected is based on the value of property preset from the default settings object. All preset objects do not have this property but have id instead, since default settings has property preset, all the presets inherit the same property preset, which is why the first preset was always highlighted. Fixed by replacing key name preset to id in default settings.

<!---
  Provide a general summary of your changes in the Title above
  Expand on it in the description below (if applicable)

  Attach a screenshot when applicable
-->

<!---
- [ ] Add integration tests (when applicable)

Closes <issue number>
-->
