### PR TITLE
Add @carbonshbot to community section on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Check out these projects our awesome community has created:
 - [Carbonize](https://itunes.apple.com/us/app/carbonize/id1451177988) - A macOS wrapper with extended native features
 - [CodeExpander](https://codeexpander.com) - A smart GitHub gist client with the TextExpander features
 - [`nef`](https://github.com/bow-swift/nef#-exporting-carbon-code-snippets) - Export multiple Carbon code snippets from `Xcode Playground`.
-- [`@carbonshbot`](https://t.me/carbonshbot) - A Telegram chatbot wich takes in a code snippet or gist URL and generates an imagem from the website.
+- [`@carbonshbot`](https://t.me/carbonshbot) - A Telegram chatbot wich takes in a code snippet or gist URL and generates an Carbon image
 
 ##### Libraries
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Check out these projects our awesome community has created:
 - [Carbonize](https://itunes.apple.com/us/app/carbonize/id1451177988) - A macOS wrapper with extended native features
 - [CodeExpander](https://codeexpander.com) - A smart GitHub gist client with the TextExpander features
 - [`nef`](https://github.com/bow-swift/nef#-exporting-carbon-code-snippets) - Export multiple Carbon code snippets from `Xcode Playground`.
+- [`@carbonshbot`](https://t.me/carbonshbot) - A Telegram chatbot wich takes in a code snippet or gist URL and generates an imagem from the website.
 
 ##### Libraries
 


### PR DESCRIPTION
Add a link to a Telegram bot which uses puppeteer to interact with the website and generate an image everytime it receives text wrapped in three backticks (```), as well as a gist URL.

Supports options for changing the overall appearance of the genrated image.
Also supports manually specifying a language as the first line of the code block.

This is how it looks:
![image](https://user-images.githubusercontent.com/3948961/73106170-88131a00-3ed9-11ea-940b-652fddadc948.png)

