### PR TITLE
chore: move prettier to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ms": "^2.1.2",
     "next": "^9.3.6",
     "next-offline": "^5.0.2",
-    "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-click-outside": "^3.0.0",
     "react-codemirror2": "^7.1.0",
@@ -76,6 +75,7 @@
     "lint-staged": "^10.2.0",
     "now": "^18.0.0",
     "now-release": "^0.0.2",
+    "prettier": "^2.0.5",
     "wait-on": "^4.0.2"
   },
   "engines": {


### PR DESCRIPTION
This very minor PR moves prettier to the dev dependencies, as it is not used in the code anywhere. 

It allows to shave 10Mb off the production bundle deps, at no cost. 

I ran the integration tests, ran and built the app locally to test everything and saw no behaviour difference. Of course do feel free to correct me if that would break anything 

Closes #1011
