### PR TITLE
refactor(color-picker): drag the pointer smoothly

### DIFF
--- a/components/ColorPicker.js
+++ b/components/ColorPicker.js
@@ -9,38 +9,57 @@ const pickerStyle = {
   margin: '0 auto 1px',
 }
 
-const ColorPicker = ({ onChange = () => {}, color, presets, style, disableAlpha }) => (
-  <React.Fragment>
-    <SketchPicker
-      styles={{ picker: style || pickerStyle }}
-      color={color}
-      onChangeComplete={onChange}
-      presetColors={presets}
-      disableAlpha={disableAlpha}
-    />
-    <style jsx>
-      {`
-        /* react-color overrides */
-        :global(.sketch-picker > div:nth-child(3) > div > div > span) {
-          color: ${COLORS.SECONDARY} !important;
-        }
+class ColorPicker extends React.PureComponent {
+  constructor(props) {
+    super(props)
+    this.state = {
+      color: props.color,
+    }
+  }
 
-        :global(.sketch-picker > div:nth-child(3) > div > div > input) {
-          width: 100% !important;
-          box-shadow: none;
-          outline: none;
-          border-radius: 2px;
-          background: ${COLORS.DARK_GRAY};
-          color: #fff !important;
-        }
+  handleColorChange = color => {
+    this.setState({ color })
+  }
 
-        /* prettier-ignore */
-        :global(.sketch-picker > div:nth-child(2) > div:nth-child(1) > div:nth-child(2), .sketch-picker > div:nth-child(2) > div:nth-child(2)) {
-          background: #fff;
+  render() {
+    const { color } = this.state
+    const { onChange = () => {}, presets, style, disableAlpha } = this.props
+
+    return (
+      <React.Fragment>
+        <SketchPicker
+          styles={{ picker: style || pickerStyle }}
+          onChange={this.handleColorChange}
+          color={color}
+          onChangeComplete={onChange}
+          presetColors={presets}
+          disableAlpha={disableAlpha}
+        />
+        <style jsx>
+          {`
+            /* react-color overrides */
+            :global(.sketch-picker > div:nth-child(3) > div > div > span) {
+              color: ${COLORS.SECONDARY} !important
+            }
+
+            :global(.sketch-picker > div:nth-child(3) > div > div > input) {
+              width: 100% !important
+              box-shadow: none
+              outline: none
+              border-radius: 2px
+              background: ${COLORS.DARK_GRAY}
+              color: #fff !important
+            }
+
+            /* prettier-ignore */
+            :global(.sketch-picker > div:nth-child(2) > div:nth-child(1) > div:nth-child(2), .sketch-picker > div:nth-child(2) > div:nth-child(2)) {
+          background: #fff
         }
-      `}
-    </style>
-  </React.Fragment>
-)
+          `}
+        </style>
+      </React.Fragment>
+    )
+  }
+}
 
 export default ColorPicker

--- a/components/ColorPicker.js
+++ b/components/ColorPicker.js
@@ -9,34 +9,22 @@ const pickerStyle = {
   margin: '0 auto 1px',
 }
 
-class ColorPicker extends React.PureComponent {
-  constructor(props) {
-    super(props)
-    this.state = {
-      color: props.color,
-    }
-  }
+export default function ColorPicker(props) {
+  const [color, setColor] = React.useState(props.color)
+  const { onChange = () => {}, presets, style, disableAlpha } = props
 
-  handleColorChange = color => {
-    this.setState({ color })
-  }
-
-  render() {
-    const { color } = this.state
-    const { onChange = () => {}, presets, style, disableAlpha } = this.props
-
-    return (
-      <React.Fragment>
-        <SketchPicker
-          styles={{ picker: style || pickerStyle }}
-          onChange={this.handleColorChange}
-          color={color}
-          onChangeComplete={onChange}
-          presetColors={presets}
-          disableAlpha={disableAlpha}
-        />
-        <style jsx>
-          {`
+  return (
+    <React.Fragment>
+      <SketchPicker
+        styles={{ picker: style || pickerStyle }}
+        onChange={setColor}
+        color={color}
+        onChangeComplete={onChange}
+        presetColors={presets}
+        disableAlpha={disableAlpha}
+      />
+      <style jsx>
+        {`
             /* react-color overrides */
             :global(.sketch-picker > div:nth-child(3) > div > div > span) {
               color: ${COLORS.SECONDARY} !important
@@ -51,15 +39,11 @@ class ColorPicker extends React.PureComponent {
               color: #fff !important
             }
 
-            /* prettier-ignore */
             :global(.sketch-picker > div:nth-child(2) > div:nth-child(1) > div:nth-child(2), .sketch-picker > div:nth-child(2) > div:nth-child(2)) {
-          background: #fff
-        }
+              background: #fff
+            }
           `}
-        </style>
-      </React.Fragment>
-    )
-  }
+      </style>
+    </React.Fragment>
+  )
 }
-
-export default ColorPicker


### PR DESCRIPTION
When dragging color picker, it's not changed color instantly, so I refactor color picker makes it works.

![Kapture 2020-06-17 at 9 05 50](https://user-images.githubusercontent.com/10325111/84843942-d76e0880-b07b-11ea-8d70-10253f3751e3.gif)

