### PR TITLE
Fix broken link to the contributing guidelines on the about page

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -107,7 +107,7 @@ export default () => (
       <div>
         <h2>I want to make this better.</h2>
         <p>
-          <a className="link" href="https://github.com/carbon-app/carbon#contribute">
+          <a className="link" href="https://github.com/carbon-app/carbon#contribute--support">
             Contributors welcome!
           </a>
         </p>


### PR DESCRIPTION
When `Contribute` header in the README file was changed by b6995ff to `Contribute & Support` the link on the [about page](https://carbon.now.sh/about) wasn't updated accordingly.