### PR TITLE
Preserve syntax highlighting when exporting png that contains %XX

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -136,7 +136,7 @@ class Editor extends React.Component {
         if (node.innerText && node.innerText.match(/%[A-Fa-f0-9]{2}/)) {
           map.set(node, node.innerHTML)
           node.innerText.match(/%[A-Fa-f0-9]{2}/g).forEach(t => {
-            node.innerText = node.innerText.replace(t, encodeURIComponent(t))
+            node.innerHTML = node.innerHTML.replace(t, encodeURIComponent(t))
           })
         }
       })


### PR DESCRIPTION
Closes #1064

This PR attempts to solve the highlighting issue described in #1064 without reintruducing any of the issues from #564. For that reason I have manually tested with the following snippets and left it as a fairly naive solution:

1. [Snippet from #1064](https://carbon.now.sh/?bg=rgba(171%2C%20184%2C%20195%2C%201)&t=one-dark&wt=none&l=text%2Fx-csrc&ds=true&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Hack&fs=14px&lh=133%25&si=false&es=1x&wm=false&code=int%2520main()%2520%257B%250A%2509printf(%2522%252510d%255Cn%2522%252C%252012345)%253B%2520char%2520s%255B1%255D%253D%2522%2522%253B%250A%2509printf(%2522format%2520string%2520%2525s%2522%252C%2520s)%253B%250A%257D%250A)
1. [Snippet from #564](https://carbon.now.sh/?bg=rgba(171%2C%20184%2C%20195%2C%201)&t=one-dark&wt=none&l=auto&ds=true&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Hack&fs=14px&lh=133%25&si=false&es=1x&wm=false&code=%2523include%2520%253Ciostream%253E%250A%2523include%2520%253Ccstring%253E%250Ausing%2520namespace%2520std%253B%250A%250Aint%2520d%255B5000%255D%255B5000%255D%253B%250A%250Aint%2520main()%250A%257B%250A%2520%2520%2520%2520int%2520T%2520%253D%252010%253B%250A%2520%2520%2520%2520while%2520(T--)%2520%257B%250A%2520%2520%2520%2520%2520%2520%2520%2520int%2520n%253B%2520scanf(%2522%2525d%2522%252C%2520%2526n)%253B%2520%2520%2520%2520%252F%252F%2520this%2520line%2520changes%2520to%2520%2522int%2520n%253B%2520scanf(%252522%252525d%252522%252C%2520%2526n)%253B%2522%250A%2520%2520%2520%2520%2520%2520%2520%2520string%2520s%253B%2520cin%253E%253Es%253B%250A%2520%2520%2520%2520%2520%2520%2520%2520%250A%2520%2520%2520%2520%2520%2520%2520%2520memset(d%252C%25200%252C%2520sizeof(d))%253B%250A%2520%2520%2520%2520%2520%2520%2520%2520%250A%2520%2520%2520%2520%2520%2520%2520%2520for%2520(int%2520i%253D0%253B%2520i%253Cn%253B%2520%252B%252Bi)%2520%257B%250A%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520d%255Bi%255D%255Bi%255D%2520%253D%25201%253B%250A%2520%2520%2520%2520%2520%2520%2520%2520%257D%250A%2520%2520%2520%2520%2520%2520%2520for%2520(int%2520i%253D0%253B%2520i%253Cn-1%253B%2520%252B%252Bi)%2520%257B%250A%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520d%255Bi%255D%255Bi%252B1%255D%2520%253D%2520(s%255Bi%255D%253D%253Ds%255Bi%252B1%255D%253F2%253A1)%253B%250A%2520%2520%2520%2520%2520%2520%2520%2520%257D%250A%2520%2520%2520%2520%2520%2520%2520%2520for%2520(int%2520l%253D2%253B%2520l%253Cn%253B%2520%252B%252Bl)%2520%257B%250A%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520for%2520(int%2520i%253D0%253B%2520i%252Bl%253Cn%253B%2520%252B%252Bi)%2520%257B%250A%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520int%2520j%2520%253D%2520i%252Bl%253B%250A%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520if%2520(s%255Bi%255D%253D%253Ds%255Bj%255D)%2520d%255Bi%255D%255Bj%255D%2520%253D%2520d%255Bi%252B1%255D%255Bj-1%255D%2520%252B%25202%253B%250A%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520else%2520d%255Bi%255D%255Bj%255D%2520%253D%2520max(d%255Bi%252B1%255D%255Bj%255D%252C%2520d%255Bi%255D%255Bj-1%255D)%253B%250A%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%2520%257D%250A%2520%2520%2520%2520%2520%2520%2520%2520%257D%250A%2520%2520%2520%2520%250A%2520%2520%2520%2520%2520%2520%2520%2520printf(%2522%2523%2525d%2520%2525d%255Cn%2522%252C%252010-T%252C%2520d%255B0%255D%255Bn-1%255D)%253B%2520%2520%2520%2520%252F%252F%2520this%2520line%2520changes%2520to%2520%2522printf(%252522%252523%252525d%252520%252525d%25255Cn%252522%252C%252010-T%252C%2520d%255B0%255D%255Bn-1%255D)%253B%250A%2520%2520%2520%2520%257D%250A%2520%2520%2520%2520%250A%2520%2520%2520%2520return%25200%253B%250A%257D)
1. [Snippet 1 from comments of #564](https://carbon.now.sh/?bg=rgba(171%2C%20184%2C%20195%2C%201)&t=one-dark&wt=none&l=auto&ds=true&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Hack&fs=14px&lh=133%25&si=false&es=1x&wm=false&code=console.log(%27%2525cconsole.log%2520can%2520be%2520fancy%2520too%27%252C%2520%27color%253A%2520green%253B%2520font-size%253A%252025px%253B%27)%253B%250Aconsole.log(%250A%2520%2520%27%2525cor...%2520%2525ceven%2525cfancier%27%252C%2520%250A%2520%2520%27color%253A%2520cornsilk%253B%2520background%253A%2520%25235C323E%253B%2520font-weight%253A%2520bold%253B%2520font-size%253A%252020px%253B%27%252C%250A%2520%2520%27color%253A%2520floralwhite%253B%2520background%253A%2520lawngreen%253B%2520font-size%253A%252025px%253B%2520margin%253A%25204px%253B%27%252C%2520%250A%2520%2520%27border-style%253A%2520dashed%253B%2520border-radius%253A%252010px%253B%2520background%253A%2520tomato%253B%2520font-size%253A%252030px%253B%2520font-style%253A%2520italic%253B%27%250A)%253B)
1. [Snippet 2 from comments of #564](https://carbon.now.sh/?bg=rgba(171%2C%20184%2C%20195%2C%201)&t=one-dark&wt=none&l=auto&ds=true&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Hack&fs=14px&lh=133%25&si=false&es=1x&wm=false&code=my%2520%2525hash%253B%250ALINE%253A%250Awhile%2520(%253C%253E)%2520%257B%250A%2509chomp%253B%250A%2509scalar(split(%2522%2520%2522%252C%2520%2524_%252C%25202))%2520%253E%25201%2520or%2520goto%2520LINE%253B%250A%2509m%252F%255Eman%2520%252F%2520and%2520goto%2520LINE%253B%250A%2509exists(%2524hash%257B%2524_%257D)%2520or%2520print(%2524_%2520.%2520%2522%255Cn%2522)%253B%250A%2509%2524hash%257B%2524_%257D%2520%253D%2520()%253B%250A%257D)

This fix assumes `%XX` never occurs within the actual markup - only in the text itself