### PR TITLE
Fix IBM Plex Mono font is missing in Safari

### DIFF
--- a/components/style/Font.js
+++ b/components/style/Font.js
@@ -75,9 +75,14 @@ export default () => (
       /* latin */
       @font-face {
         font-family: 'IBM Plex Mono';
+        font-display: swap;
+        font-weight: 500;
         src: local('IBM Plex Mono Medium Italic'), local('IBMPlexMono-MediumItalic'),
           url(https://fonts.gstatic.com/s/ibmplexmono/v2/-F6sfjptAgt5VM-kVkqdyU8n1ioSJlR1gMoQPttozw.woff2)
             format('woff2');
+        unicode-range: U + 0000-00ff, U + 0131, U + 0152-0153, U + 02bb-02bc, U + 02c6, U + 02da,
+          U + 02dc, U + 2000-206f, U + 2074, U + 20ac, U + 2122, U + 2191, U + 2193, U + 2212,
+          U + 2215, U + FEFF, U + FFFD;
       }
 
       /* latin */

--- a/components/style/Font.js
+++ b/components/style/Font.js
@@ -75,15 +75,9 @@ export default () => (
       /* latin */
       @font-face {
         font-family: 'IBM Plex Mono';
-        font-display: swap;
-        font-style: italic;
-        font-weight: 500;
         src: local('IBM Plex Mono Medium Italic'), local('IBMPlexMono-MediumItalic'),
           url(https://fonts.gstatic.com/s/ibmplexmono/v2/-F6sfjptAgt5VM-kVkqdyU8n1ioSJlR1gMoQPttozw.woff2)
             format('woff2');
-        unicode-range: U + 0000-00ff, U + 0131, U + 0152-0153, U + 02bb-02bc, U + 02c6, U + 02da,
-          U + 02dc, U + 2000-206f, U + 2074, U + 20ac, U + 2122, U + 2191, U + 2193, U + 2212,
-          U + 2215, U + FEFF, U + FFFD;
       }
 
       /* latin */


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above

Expand on it in the description below (if applicable)
Attach a screenshot (if applicable)
-->
According to #1044 issue, IBM Plex Mono won't loaded properly in Safari web browser. I remove some attributes when load font with `@font-face` and now it's loaded properly.

Before
![image](https://user-images.githubusercontent.com/15377132/90092707-cf68d700-dd53-11ea-8fc4-0f7ac62edca3.png)

After
<img width="1436" alt="Screen Shot 2020-08-13 at 10 58 21" src="https://user-images.githubusercontent.com/15377132/90092742-ea3b4b80-dd53-11ea-85e1-4603cd0ee464.png">

Fixes #1044 