### PR TITLE
Fix typo in scrollbarStyle option

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -159,7 +159,7 @@ class Carbon extends React.PureComponent {
       firstLineNumber: config.firstLineNumber,
       mode: languageMode || 'plaintext',
       theme: config.theme,
-      scrollBarStyle: null,
+      scrollbarStyle: null,
       viewportMargin: Infinity,
       lineWrapping: true,
       smartIndent: true,
@@ -245,15 +245,13 @@ class Carbon extends React.PureComponent {
             }
 
             .container .bg {
-              ${
-                this.props.config.backgroundMode === 'image'
-                  ? `background: url(${backgroundImage});
+              ${this.props.config.backgroundMode === 'image'
+                ? `background: url(${backgroundImage});
                     background-size: cover;
                     background-repeat: no-repeat;`
-                  : `background: ${this.props.config.backgroundColor || config.backgroundColor};
+                : `background: ${this.props.config.backgroundColor || config.backgroundColor};
                     background-size: auto;
-                    background-repeat: repeat;`
-              }
+                    background-repeat: repeat;`}
               position: absolute;
               top: 0px;
               right: 0px;
@@ -280,11 +278,9 @@ class Carbon extends React.PureComponent {
               position: relative;
               z-index: 1;
               border-radius: 5px;
-              ${
-                config.dropShadow
-                  ? `box-shadow: 0 ${config.dropShadowOffsetY} ${config.dropShadowBlurRadius} rgba(0, 0, 0, 0.55)`
-                  : ''
-              };
+              ${config.dropShadow
+                ? `box-shadow: 0 ${config.dropShadowOffsetY} ${config.dropShadowBlurRadius} rgba(0, 0, 0, 0.55)`
+                : ''};
             }
 
             .container :global(.CodeMirror__container .CodeMirror) {


### PR DESCRIPTION
The option would be ignored when exporting the project through `next build && next export`, failing to hide the vertical scroller.

(Additional changes were presumable made automatically by the linter.)

<img width="970" alt="Screen Shot 2020-10-01 at 11 04 56" src="https://user-images.githubusercontent.com/225410/94790004-f8156080-03d5-11eb-9434-279230ccb687.png">
