### PR TITLE
Updated base16-light operator color to black

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -121,7 +121,7 @@ export const THEMES = [
       attribute: '#90a959',
       definition: '#d28445',
       keyword: '#ac4142',
-      operator: '#fff',
+      operator: '#000',
       property: '#90a959',
       number: '#aa759f',
       string: '#f4bf75',


### PR DESCRIPTION
Updated base16-light operator color to black (#000) instead of white (#fff)

- [x] Integration tests (if applicable)

Closes #1121
