### PR TITLE
Fix sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Pull requests are welcome! Please see our [contributing guidelines](/.github/CON
 
 Does your company use Carbon? Consider sponsoring the project to fund new features, bug fixes, and more.
 
-<a href="https://fossa.com" style="margin-right: 2rem;" target="_blank"><img width="280px" src="https://fossa.com/wp-content/themes/rs_theme/assets/images/logo.svg" /></a>
+<a href="https://fossa.com" style="margin-right: 2rem;" target="_blank"><img width="180px" src="https://assets-global.website-files.com/5f4d9ea2592c16056cb0f7a5/5f4d9ea2592c16d9a2b0f7da_logo-FOSSA-night-blue.svg" /></a>
 <a href="https://opencollective.com/carbon-app/sponsors/0/website" target="_blank"><img src="https://opencollective.com/carbon-app/sponsors/0/avatar"></a>
 <a href="https://opencollective.com/carbon-app/sponsors/1/website" target="_blank"><img src="https://opencollective.com/carbon-app/sponsors/1/avatar"></a>
 <a href="https://opencollective.com/carbon-app/sponsors/2/website" target="_blank"><img src="https://opencollective.com/carbon-app/sponsors/2/avatar"></a>


### PR DESCRIPTION
Previous image was broken. Appears to have been deleted by Fossa as part of new brand guidelines: https://fossa.com/brand

Closes #1145
