### PR TITLE
share menu tags fixed

### DIFF
--- a/components/ShareMenu.js
+++ b/components/ShareMenu.js
@@ -40,7 +40,7 @@ function ShareMenu({ isVisible, toggleVisibility, tweet, imgur }) {
           {tweeting ? 'Loading…' : 'Tweet'}
         </Button>
         <Button
-          id="export-menu"
+          id="share-menu"
           border
           large
           center
@@ -48,9 +48,9 @@ function ShareMenu({ isVisible, toggleVisibility, tweet, imgur }) {
           padding="0 8px"
           margin="0 8px 0 -1px"
           onClick={toggleVisibility}
-          data-cy="export-button"
+          data-cy="share-button"
           style={{ borderBottomLeftRadius: 0, borderTopLeftRadius: 0 }}
-          title="Export menu dropdown"
+          title="Share menu dropdown"
         >
           <ArrowDown color={COLORS.BLUE} />
         </Button>


### PR DESCRIPTION
when tweet and imgur buttons were merged in #1158 to ShareMenu component, tags were copied and pasted from the ExportMenu component. duplicate id tags were causing integration tests to fail. id and other tags updated to correspond to "share" rather than "export"

notes: there are no integration tests for the new ShareMenu component. also, the integration test for downloading images is failing and outdated, although it is skipped and not a part of CI so low priority

Closes #1171 
