### PR TITLE
IBM Plex Mono (Medium Italic -> Regular)

### DIFF
--- a/components/style/Font.js
+++ b/components/style/Font.js
@@ -66,8 +66,8 @@ export default function Font() {
           font-family: 'IBM Plex Mono';
           font-display: swap;
           font-weight: 500;
-          src: local('IBM Plex Mono Medium Italic'), local('IBMPlexMono-MediumItalic'),
-            url(https://fonts.gstatic.com/s/ibmplexmono/v2/-F6sfjptAgt5VM-kVkqdyU8n1ioSJlR1gMoQPttozw.woff2)
+          src: local('IBM Plex Mono Regular'), local('IBMPlexMono-Regular'),
+            url(//fonts.gstatic.com/s/ibmplexmono/v6/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2)
               format('woff2');
         }
 


### PR DESCRIPTION
Changes @font-face definition of IBM Plex Mono from "Medium Italic" to "Regular."

- "Regular" rather than "Medium" to align with all other font definitions
- Users can still create italic screenshots by highlighting their code and clicking the italic button

Closes #1177

