### PR TITLE
Fira Code Font - Set to latest version, switch CDN

### DIFF
--- a/components/style/Font.js
+++ b/components/style/Font.js
@@ -46,9 +46,9 @@ export default function Font() {
         @font-face {
           font-family: 'Fira Code';
           font-display: swap;
-          src: url('//cdn.rawgit.com/tonsky/FiraCode/1.204/distr/woff2/FiraCode-Regular.woff2')
+          src: url('//cdn.jsdelivr.net/npm/firacode@latest/distr/woff2/FiraCode-Regular.woff2')
               format('woff2'),
-            url('//cdn.rawgit.com/tonsky/FiraCode/1.204/distr/woff/FiraCode-Regular.woff')
+            url('//cdn.jsdelivr.net/npm/firacode@latest/distr/woff/FiraCode-Regular.woff')
               format('woff');
         }
 


### PR DESCRIPTION
As @vtmx points out in #1181, Carbon is sourcing a pretty old version of the Fira Code font. This commit uses the `@latest` version. Also, changes cdn from rawgit (which is discontinued) to jsDelivr.

Closes #1181
