### PR TITLE
Don't sanitize payload for storage

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,11 +1,10 @@
 import axios from 'axios'
 import debounce from 'lodash.debounce'
-import omitBy from 'lodash.omitby'
 import ms from 'ms'
 
 import { fileToDataURL } from './util'
 import firebase from './client'
-import { DEFAULT_CODE, DEFAULT_SETTINGS } from './constants'
+import { DEFAULT_CODE } from './constants'
 
 export const client = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_API_URL || ''}/api`,
@@ -130,15 +129,9 @@ function listSnippets(page) {
     )
 }
 
-function isNotDefaultSetting(v, k) {
-  return v === DEFAULT_SETTINGS[k] || !Object.prototype.hasOwnProperty.call(DEFAULT_SETTINGS, k)
-}
-
 function updateSnippet(uid, state) {
-  const sanitized = omitBy(state, isNotDefaultSetting)
-
   const data = {
-    ...sanitized,
+    ...state,
     code: state.code != null ? state.code : DEFAULT_CODE,
   }
 


### PR DESCRIPTION
Reverts the changes of commit 520e19ab44065622a7a47c22d60ccd70de0e68bc. Setting changes to default values are no longer removed from the Firebase payload, avoiding the bug described in #1183. Passes E2E tests but I don't have a means to test Firebase network requests locally - @mfix22 can you share a deployment link, or test yourself if that's easier.

Closes #1183, although another change is required on backend to avoid storing default values.
