### PR TITLE
Upgrade codemirror package to 5.65.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "axios": "^0.24.0",
     "chrome-aws-lambda": "^8.0.2",
     "cm-show-invisibles": "^3.1.0",
-    "codemirror": "5.64.0",
+    "codemirror": "5.65.1",
     "codemirror-graphql": "^1.2.11",
     "codemirror-mode-elixir": "^1.1.2",
     "codemirror-solidity": "^0.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3381,10 +3381,10 @@ codemirror-solidity@^0.2.3:
   dependencies:
     codemirror "^5.56.0"
 
-codemirror@5.64.0:
-  version "5.64.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.64.0.tgz#182eec65b62178e3cd1de8f9d88ab819cfe5f625"
-  integrity sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg==
+codemirror@5.65.1:
+  version "5.65.1"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.1.tgz#5988a812c974c467f964bcc1a00c944e373de502"
+  integrity sha512-s6aac+DD+4O2u1aBmdxhB7yz2XU7tG3snOyQ05Kxifahz7hoxnfxIRHxiCSEv3TUC38dIVH8G+lZH9UWSfGQxA==
 
 codemirror@^5.56.0:
   version "5.58.2"


### PR DESCRIPTION
Fixes #1308.

The upgrade fixes Fortran syntax highlighting issues identified in
the upstream package.