### PR TITLE
Add separate language mode for F#

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -730,6 +730,13 @@ export const LANGUAGES = [
     highlight: true,
   },
   {
+    name: 'F#',
+    mime: 'text/x-fsharp',
+    mode: 'mllike',
+    short: 'fsharp',
+    highlight: true,
+  },
+  {
     name: 'Fortran',
     mode: 'fortran',
     highlight: true,
@@ -870,7 +877,7 @@ export const LANGUAGES = [
     highlight: true,
   },
   {
-    name: 'OCaml/F#',
+    name: 'OCaml',
     mode: 'mllike',
     short: 'ocaml',
     highlight: true,


### PR DESCRIPTION
CodeMirror's `mllike` mode has sub-support for F# if provided the `text/x-fsharp` MIME type, so I've done so here.

I found this at CodeMirror's documentation for the `mllike` mode [here](https://codemirror.net/mode/mllike/index.html).

Before:
![FK9W61oXoAAX0rm](https://user-images.githubusercontent.com/573979/152716197-370e6fe8-1b71-4eb4-b2ed-44218cda7de4.jpg)

After:
![after](https://user-images.githubusercontent.com/573979/152716219-f3bcc7e6-acdb-4e98-92f6-48f2690a71ed.png)

