### PR TITLE
Fix: Responsive design at the largest font size

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -355,6 +355,9 @@ class Carbon extends React.PureComponent {
               .container :global([contenteditable='true']) {
                 user-select: text;
               }
+              .container {
+                max-width: 480px;
+              }
             }
 
             .section,
@@ -365,6 +368,7 @@ class Carbon extends React.PureComponent {
               justify-content: center;
               align-items: center;
               overflow: hidden;
+              max-width: 100%;
             }
           `}
         </style>


### PR DESCRIPTION
The code should not overflow on mobile when using the largest font size.

Detail: https://github.com/carbon-app/carbon/issues/1287#issuecomment-1032739971

<!---
Provide a general summary of your changes in the Title above

Expand on it in the description below (if applicable)
Attach a screenshot (if applicable)
-->

### Setting Parameters
- Editor -> Setting Max Size
- Window -> Setting Max Padding Horizontal Size


<img width="300" src="https://user-images.githubusercontent.com/16137809/153385652-04735963-85fc-43f7-96c5-0a5da3a7f4b2.png"><img width="300" src="https://user-images.githubusercontent.com/16137809/153385662-b2ef0f81-e04d-4aa4-bbbe-5e15b9407dec.png">


## Before
![スクリーンショット 2022-02-10 19 07 26](https://user-images.githubusercontent.com/16137809/153386217-b1bc9563-70af-422a-9c6f-8a05eaed0c67.png)

## After
![スクリーンショット 2022-02-10 19 06 49](https://user-images.githubusercontent.com/16137809/153386270-b86f8d35-fdaf-4efd-9605-37352a61ece5.png)


Closes #1287

- [ ] Integration tests (if applicable)