### PR TITLE
Change account.js to reflect embeds are free

### DIFF
--- a/pages/account.js
+++ b/pages/account.js
@@ -80,7 +80,7 @@ function Plan({ selectBilling }) {
           </tr>
           <tr>
             <td>Embed saved snippets</td>
-            <td></td>
+            <td>✔</td>
             <td>✔</td>
           </tr>
           <tr>


### PR DESCRIPTION
As stated in #1336, embedding saved snippets is part of the Free tier, but on the account page it is listed as part of the Diamand tier.

This MR fixes that.