### PR TITLE
Fix an issue where exported images would be smaller

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -245,6 +245,9 @@ class Carbon extends React.PureComponent {
               max-width: ${config.widthAdjustment ? '1024px' : 'none'};
               ${config.widthAdjustment ? '' : `width: ${config.width}px;`}
               padding: ${config.paddingVertical} ${config.paddingHorizontal};
+              overflow: scroll;
+              margin: 0 auto;
+              scroll-snap-align: center;
             }
 
             .container :global(.watermark) {
@@ -355,9 +358,6 @@ class Carbon extends React.PureComponent {
               .container :global([contenteditable='true']) {
                 user-select: text;
               }
-              .container {
-                max-width: 480px;
-              }
             }
 
             .section,
@@ -367,8 +367,9 @@ class Carbon extends React.PureComponent {
               flex-direction: column;
               justify-content: center;
               align-items: center;
-              overflow: hidden;
+              overflow: scroll;
               max-width: 100%;
+              scroll-snap-type: x mandatory;
             }
           `}
         </style>

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -93,6 +93,16 @@ class Editor extends React.Component {
   updateCode = code => this.updateState({ code })
   updateWidth = width => this.setState({ widthAdjustment: false, width })
 
+  calculateExportImageBaseWidth = offsetWidth => {
+    if (this.state.widthAdjustment) return offsetWidth
+
+    const settingWidth = parseInt(this.state.width)
+    const isOverWidth = offsetWidth < settingWidth
+    if (!isOverWidth) return offsetWidth
+
+    return settingWidth + parseInt(this.state.paddingHorizontal)
+  }
+
   getCarbonImage = async (
     {
       format,
@@ -101,9 +111,9 @@ class Editor extends React.Component {
     } = { format: 'png' }
   ) => {
     const node = this.carbonNode.current
-
-    const width = node.offsetWidth * exportSize
-    const height = squared ? node.offsetWidth * exportSize : node.offsetHeight * exportSize
+    const imageBaseWidth = this.calculateExportImageBaseWidth(node.offsetWidth)
+    const width = imageBaseWidth * exportSize
+    const height = squared ? imageBaseWidth * exportSize : node.offsetHeight * exportSize
 
     const config = {
       style: {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above

Expand on it in the description below (if applicable)
Attach a screenshot (if applicable)
-->

- [x] Integration tests (if applicable)

Closes #1287

### Issue Summary
When viewing on mobile, increasing width makes it responsive.
However, the exported image was also responsive and vertically long.
Detail: https://github.com/carbon-app/carbon/issues/1287#issuecomment-1055586425

### Solution
- When the set width is larger than the displayed width, the width of the exported image is calculated using the set width.
- Changed the display from responsive to scrolling
  - https://github.com/carbon-app/carbon/issues/1287#issuecomment-1032739971 
  - > You can no longer view your code, as it is horizontally unscrollable.

https://user-images.githubusercontent.com/16137809/158049188-c1a047de-5080-45a1-8b5d-1c55aa4a0725.mov
