### PR TITLE
chore: fix rate limit message typo

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -32,7 +32,7 @@ const RATE_LIMIT_CODE = 420
 function checkIfRateLimited(err) {
   if (err.response.status === RATE_LIMIT_CODE) {
     alert(
-      "Oh no! Looks like to many people are trying to tweet right now and we've been rate limited. Try again soon or save and upload manually!"
+      "Oh no! Looks like too many people are trying to tweet right now and we've been rate limited. Try again soon or save and upload manually!"
     )
     return
   }


### PR DESCRIPTION
`to` -> `too`

