### PR TITLE
(feat: side card) Add side-card panel to add text information to the code 

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -199,6 +199,11 @@ class Carbon extends React.PureComponent {
             </div>
           ) : (
             <div className="container">
+              <div className="side-card">
+                <h2>FluentAssertions Exceptions</h2>
+                <p>O FluentAssertions tem métodos pra checar Exceptions também. Dá pra checar que uma exception foi lançada ou que não foi lançada por uma chamada. <br /> <br /> Os métodos te ajudam a checar mensagens, parâmetros e outros detalhes de forma mais fácil.</p>
+              </div>
+            <div>
               {config.windowControls ? (
                 <WindowControls
                   theme={config.windowTheme}
@@ -229,6 +234,7 @@ class Carbon extends React.PureComponent {
                 paddingHorizontal={config.paddingHorizontal}
               />
             </div>
+          </div>
           )}
         </div>
         {selectionNode &&
@@ -239,12 +245,46 @@ class Carbon extends React.PureComponent {
           )}
         <style jsx>
           {`
+            div.side-card {
+              position: relative;
+              background-color: rgba(255,255,255,0.7);
+              width: auto;
+              z-index: 1;
+              margin-right: -5px;
+              border-radius: 5px 0 0 5px;
+              padding: 5px;
+              padding-top: 24px;
+              padding-right: 10px;
+              color: black;
+              font-family: Lato, sans-serif;
+              max-width: 320px;
+              max-height: 100%;
+              line-height: normal;
+            }
+
+            div.side-card > h2 {
+              font-weight: 900;
+              font-size: 28px;
+              margin: 0;
+              margin-left: 16px;
+              margin-bottom: 10px;
+            }
+
+            div.side-card > p {
+              margin: 0;
+              margin-left: 16px;
+              font-size: 20px;
+              line-height: 22px;
+              font-weight: 500;
+            }
+
             .container {
               position: relative;
               min-width: ${config.widthAdjustment ? '90px' : 'auto'};
               max-width: ${config.widthAdjustment ? '1024px' : 'none'};
               ${config.widthAdjustment ? '' : `width: ${config.width}px;`}
               padding: ${config.paddingVertical} ${config.paddingHorizontal};
+              display: flex;
             }
 
             .container :global(.watermark) {

--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -260,6 +260,7 @@ class Carbon extends React.PureComponent {
               max-width: 320px;
               max-height: 100%;
               line-height: normal;
+              ${this.props.config.sideCard !== true ? 'display: none' : ''}
             }
 
             div.side-card > .title {

--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -200,8 +200,8 @@ class Carbon extends React.PureComponent {
           ) : (
             <div className="container">
               <div className="side-card">
-                <h2>FluentAssertions Exceptions</h2>
-                <p>O FluentAssertions tem métodos pra checar Exceptions também. Dá pra checar que uma exception foi lançada ou que não foi lançada por uma chamada. <br /> <br /> Os métodos te ajudam a checar mensagens, parâmetros e outros detalhes de forma mais fácil.</p>
+                <h2 className="title">FluentAssertions Exceptions</h2>
+                <textarea className="body">Some description text</textarea>
               </div>
             <div>
               {config.windowControls ? (
@@ -262,7 +262,7 @@ class Carbon extends React.PureComponent {
               line-height: normal;
             }
 
-            div.side-card > h2 {
+            div.side-card > .title {
               font-weight: 900;
               font-size: 28px;
               margin: 0;
@@ -270,12 +270,21 @@ class Carbon extends React.PureComponent {
               margin-bottom: 10px;
             }
 
-            div.side-card > p {
+            div.side-card > .body {
               margin: 0;
               margin-left: 16px;
+              background: none;
+              resize: none;
+              overflow: hidden;
+              outline: none;
+              box-shadow: none;
+              border: none;
               font-size: 20px;
               line-height: 22px;
               font-weight: 500;
+              height: 100%;
+              width: ${320 - 26}px;
+              font-family: Lato, sans-serif;
             }
 
             .container {

--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -200,8 +200,8 @@ class Carbon extends React.PureComponent {
           ) : (
             <div className="container">
               <div className="side-card">
-                <h2 className="title">FluentAssertions Exceptions</h2>
-                <textarea className="body">Some description text</textarea>
+                <textarea className="title" defaultValue={"Nice title"}></textarea>
+                <textarea className="body" defaultValue={"Some description text"}></textarea>
               </div>
             <div>
               {config.windowControls ? (
@@ -264,11 +264,19 @@ class Carbon extends React.PureComponent {
             }
 
             div.side-card > .title {
-              font-weight: 900;
-              font-size: 28px;
               margin: 0;
               margin-left: 16px;
               margin-bottom: 10px;
+              background: none;
+              resize: none;
+              overflow: hidden;
+              outline: none;
+              box-shadow: none;
+              border: none;
+              font-weight: 900;
+              font-size: 28px;
+              width: ${320 - 26}px;
+              font-family: Lato, sans-serif;
             }
 
             div.side-card > .body {

--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -204,7 +204,7 @@ class Carbon extends React.PureComponent {
             <div className="container">
               <div className="side-card">
                 <textarea className="title" defaultValue={this.props.config.sideCardTitle ?? 'Nice title'} onChange={this.onSideCardTitleChange}></textarea>
-                <textarea className="body" defaultValue={this.props.config.sideCardBody ??"Some description text"} onChange={this.onSideCardBodyChange}></textarea>
+                <textarea className="body" defaultValue={this.props.config.sideCardBody ?? 'Some description text'} onChange={this.onSideCardBodyChange}></textarea>
               </div>
             <div>
               {config.windowControls ? (

--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -124,6 +124,9 @@ class Carbon extends React.PureComponent {
     }
   }
 
+  onSideCardTitleChange = e => this.props.onSideCardChange({sideCardTitle: e.target.value})
+  onSideCardBodyChange = e => this.props.onSideCardChange({sideCardBody: e.target.value})
+
   onSelectionChange = changes => {
     if (this.state.selectionAt) {
       const css = [
@@ -200,8 +203,8 @@ class Carbon extends React.PureComponent {
           ) : (
             <div className="container">
               <div className="side-card">
-                <textarea className="title" defaultValue={"Nice title"}></textarea>
-                <textarea className="body" defaultValue={"Some description text"}></textarea>
+                <textarea className="title" defaultValue={this.props.config.sideCardTitle ?? 'Nice title'} onChange={this.onSideCardTitleChange}></textarea>
+                <textarea className="body" defaultValue={this.props.config.sideCardBody ??"Some description text"} onChange={this.onSideCardBodyChange}></textarea>
               </div>
             <div>
               {config.windowControls ? (

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -92,6 +92,7 @@ class Editor extends React.Component {
 
   updateCode = code => this.updateState({ code })
   updateWidth = width => this.setState({ widthAdjustment: false, width })
+  updateSideCard = sideCardProps => this.updateState(sideCardProps)
 
   getCarbonImage = async (
     {
@@ -388,6 +389,7 @@ class Editor extends React.Component {
                 ref={this.carbonNode}
                 config={this.state}
                 onChange={this.updateCode}
+                onSideCardChange={this.updateSideCard}
                 updateWidth={this.updateWidth}
                 loading={this.state.loading}
                 theme={theme}

--- a/components/Settings.js
+++ b/components/Settings.js
@@ -34,6 +34,7 @@ function WindowSettings({
   watermark,
   onWidthChanging,
   onWidthChanged,
+  sideCard,
 }) {
   return (
     <div className="settings-content">
@@ -94,6 +95,11 @@ function WindowSettings({
           />
         </div>
       )}
+      <Toggle
+        label="Enable side-card"
+        enabled={sideCard}
+        onChange={onChange.bind(null, 'sideCard')}
+      />
       <Toggle label="Watermark" enabled={watermark} onChange={onChange.bind(null, 'watermark')} />
       <style jsx>
         {`
@@ -384,6 +390,7 @@ class Settings extends React.PureComponent {
             widthAdjustment={this.props.widthAdjustment}
             width={this.props.width}
             watermark={this.props.watermark}
+            sideCard={this.props.sideCard}
           />
         )
       case 'Editor':

--- a/cypress/integration/side-card-spec.js
+++ b/cypress/integration/side-card-spec.js
@@ -28,4 +28,16 @@ describe('Side-card', () => {
     sideCardVisibile()
       .contains('Some description text')
   })
+
+  it('Should accept values from url', () => {
+    cy.visit('/?sc=true&scT=New%2520Title&scB=New%2520Body')
+    
+    editorVisible()
+
+    sideCardVisibile().within(() => {
+      cy.get('.title').contains('New Title')
+      cy.get('.body').contains('New Body')
+    })
+    
+  })
 })

--- a/cypress/integration/side-card-spec.js
+++ b/cypress/integration/side-card-spec.js
@@ -1,12 +1,12 @@
 /* global cy */
-import { editorVisible } from '../support'
+import { editorVisible, sideCardNotVisible, sideCardVisibile } from '../support'
 describe('Side-card', () => {
   it('Should be closed by default', () => {
     cy.visit('/')
     
     editorVisible()
 
-    cy.get('.side-card').should('not.be.visible')
+    sideCardNotVisible()
   })
 
   it('Should be closed when url indicates to', () => {
@@ -14,7 +14,7 @@ describe('Side-card', () => {
     
     editorVisible()
 
-    cy.get('.side-card').should('not.be.visible')
+    sideCardNotVisible()
   })
 
   it('Should be opened with default texts when url indicates to', () => {
@@ -22,11 +22,10 @@ describe('Side-card', () => {
     
     editorVisible()
 
-    cy.get('.side-card')
-      .should('be.visible')
+    sideCardVisibile()
       .contains('Nice title')
     
-    cy.get('.side-card')
+    sideCardVisibile()
       .contains('Some description text')
   })
 })

--- a/cypress/integration/side-card-spec.js
+++ b/cypress/integration/side-card-spec.js
@@ -1,0 +1,32 @@
+/* global cy */
+import { editorVisible } from '../support'
+describe('Side-card', () => {
+  it('Should be closed by default', () => {
+    cy.visit('/')
+    
+    editorVisible()
+
+    cy.get('.side-card').should('not.be.visible')
+  })
+
+  it('Should be closed when url indicates to', () => {
+    cy.visit('/?sc=false')
+    
+    editorVisible()
+
+    cy.get('.side-card').should('not.be.visible')
+  })
+
+  it('Should be opened with default texts when url indicates to', () => {
+    cy.visit('/?sc=true')
+    
+    editorVisible()
+
+    cy.get('.side-card')
+      .should('be.visible')
+      .contains('Nice title')
+    
+    cy.get('.side-card')
+      .contains('Some description text')
+  })
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,3 +1,5 @@
 /* global cy */
 // import '@applitools/eyes-cypress/commands'
 export const editorVisible = () => cy.get('.editor').should('be.visible')
+export const sideCardVisibile = () => cy.get('.side-card').should('be.visible')
+export const sideCardNotVisible = () => cy.get('.side-card').should('not.be.visible')

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1105,6 +1105,7 @@ export const DEFAULT_SETTINGS = {
   hiddenCharacters: false,
   name: '',
   width: 680,
+  sideCard: false,
 }
 
 export const DEFAULT_WIDTHS = {

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -83,6 +83,8 @@ const readMappings = [
   { field: 'highlights', type: 'parse' },
   { field: 'code', type: 'decode' },
   { field: 'sc:sideCard', type: 'bool'},
+  { field: 'scT:sideCardTitle', type: 'decode'},
+  { field: 'scB:sideCardBody', type: 'decode'},
 ]
 
 const writeMappings = [
@@ -108,6 +110,8 @@ const writeMappings = [
   { field: 'watermark:wm', type: 'bool' },
   { field: 'code', type: 'encode' },
   { field: 'sideCard:sc', type: 'bool'},
+  { field: 'sideCardTitle:scT', type: 'encode'},
+  { field: 'sideCardBody:scB', type: 'encode'},
 ]
 
 export const serializeState = state => {

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -82,6 +82,7 @@ const readMappings = [
   { field: 'id' },
   { field: 'highlights', type: 'parse' },
   { field: 'code', type: 'decode' },
+  { field: 'sc:sideCard', type: 'bool'},
 ]
 
 const writeMappings = [
@@ -106,6 +107,7 @@ const writeMappings = [
   { field: 'exportSize:es' },
   { field: 'watermark:wm', type: 'bool' },
   { field: 'code', type: 'encode' },
+  { field: 'sideCard:sc', type: 'bool'},
 ]
 
 export const serializeState = state => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -26,6 +26,9 @@ export const saveSettings = morph.compose(
     'fontUrl',
     'selectedLines',
     'name',
+    'sideCard',
+    'sideCardTitle',
+    'sideCardBody'
   ])
 )
 export const savePresets = morph.compose(


### PR DESCRIPTION
This feature will enable the user to use an aditional panel to add contextual information related to code. I saw a lot of people using this template in social media (I'm included on this), but we need to make the snippet on Carbon and then use a image editor to make the rest.

This PR incudes:
 - A new setting inside Editor tab: Enable side card
 - Encode and decode of setting, title and body in URL

I took some decisions related to design:
 - font-size and family used values that are good to read. Family: `Lato sans-serif`, title size `28px` and body size `20px`;
 - side card background color and opacity used an option that allow the original background to appear and did not difficult the user to read the text. Color `white` and opacity `0.7`;

This is something that we can evolve in the future making a specific tab in the settings, enabling the user to select those properties if needed.


https://user-images.githubusercontent.com/3756185/163623967-4eaab166-9f97-498c-bd8b-f07de80180b7.mov



- [x] Integration tests 

Closes #1364
