### PR TITLE
[BugFix] Fix exported image cut off - Safari

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -108,10 +108,12 @@ class Editor extends React.Component {
     const width = node.offsetWidth * exportSize
     const height = squared ? node.offsetWidth * exportSize : node.offsetHeight * exportSize
 
+    const transformOrigin = window.navigator.userAgent.indexOf('Safari') !== -1 ? '0 50%' : 'center'
+
     const config = {
       style: {
         transform: `scale(${exportSize})`,
-        'transform-origin': 'center',
+        'transform-origin': transformOrigin,
         background: squared ? this.state.backgroundColor : 'none',
       },
       filter: n => {


### PR DESCRIPTION
when exporting on safari, the image is offset to the left by 50%.
I adjusted the transform configuration to counter that position offset *ONLY* when `Safari` is detected in the user agent.

tested to work on the various resolutions (1x, 2x, 4x) for "download" and "open"

before:
![carbon-4](https://user-images.githubusercontent.com/3421731/185792215-f8284e46-96bf-460f-9c6a-b9db841d273f.png)

After:
![carbon-7](https://user-images.githubusercontent.com/3421731/185792204-abd73f8d-a4c8-4d6c-99b4-898c348d915e.png)

Closes #1351
