### PR TITLE
Add support for Nix

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -870,6 +870,11 @@ export const LANGUAGES = [
     highlight: true,
   },
   {
+    name: 'Nix',
+    mode: 'nix',
+    highlight: true,
+  },
+  {
     name: 'Objective C',
     mode: 'clike',
     mime: 'text/x-objectivec',


### PR DESCRIPTION
This PR adds support for [Nix](https://nixos.org) to Carbon. On several occasions I've wanted to use Carbon for snippets of Nix code but have needed to use JavaScript or Ruby instead, which kinda works but doesn't look awesome. As Nix is already supported by Highlight.js, it seemed worth a try PRing support.