### PR TITLE
Allowing a user to toggle showing the coding language in a screenshot

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -184,6 +184,8 @@ class Carbon extends React.PureComponent {
       !!this.state.selectionAt &&
       document.getElementById('style-editor-button')
 
+    const codeLanguage = searchLanguage(languageMode).name
+
     return (
       <div className="section">
         <div
@@ -206,6 +208,9 @@ class Carbon extends React.PureComponent {
                   theme={config.windowTheme}
                   code={this.props.children}
                   copyable={this.props.copyable}
+                  displayingCodeLanguage={config.displayingCodeLanguage}
+                  fontFamily={config.fontFamily}
+                  codeLanguage={codeLanguage}
                   light={light}
                 />
               ) : null}

--- a/components/Settings.js
+++ b/components/Settings.js
@@ -25,6 +25,7 @@ function WindowSettings({
   windowTheme,
   paddingHorizontal,
   paddingVertical,
+  displayingCodeLanguage,
   dropShadow,
   dropShadowBlurRadius,
   dropShadowOffsetY,
@@ -95,6 +96,11 @@ function WindowSettings({
         </div>
       )}
       <Toggle label="Watermark" enabled={watermark} onChange={onChange.bind(null, 'watermark')} />
+      <Toggle
+        label="Display Language"
+        enabled={displayingCodeLanguage}
+        onChange={onChange.bind(null, 'displayingCodeLanguage')}
+      />
       <style jsx>
         {`
           .width-row {
@@ -377,6 +383,7 @@ class Settings extends React.PureComponent {
             windowTheme={this.props.windowTheme}
             paddingHorizontal={this.props.paddingHorizontal}
             paddingVertical={this.props.paddingVertical}
+            displayingCodeLanguage={this.props.displayingCodeLanguage}
             dropShadow={this.props.dropShadow}
             dropShadowBlurRadius={this.props.dropShadowBlurRadius}
             dropShadowOffsetY={this.props.dropShadowOffsetY}

--- a/components/WindowControls.js
+++ b/components/WindowControls.js
@@ -86,10 +86,14 @@ export default function WindowControls({
   light,
   titleBar,
   onTitleBarChange,
+  displayingCodeLanguage,
+  codeLanguage,
+  fontFamily,
 }) {
   return (
     <div className="window-controls">
       {WINDOW_THEMES_MAP[theme] || <Controls />}
+      {displayingCodeLanguage && <span className="code-title">{codeLanguage}</span>}
       <TitleBar value={titleBar} onChange={onTitleBarChange} light={light} />
       {copyable && (
         <div className="copy-button">
@@ -113,6 +117,14 @@ export default function WindowControls({
             position: absolute;
             top: 0px;
             right: 16px;
+          }
+
+          .code-title {
+            font-size: 14px;
+            margin-left: 24px;
+            font-family: ${fontFamily};
+            position: absolute;
+            top: 2px;
           }
         `}
       </style>

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1116,6 +1116,7 @@ export const DEFAULT_SETTINGS = {
   hiddenCharacters: false,
   name: '',
   width: 680,
+  displayingCodeLanguage: false,
 }
 
 export const DEFAULT_WIDTHS = {


### PR DESCRIPTION
This is for the issue #1399. As you can see in the images below, you can now toggle "Display Language" so that you can see what language the code is written in for the screenshot. 

I was unsure as to whether this should be on by default, to be on the safe side I have defaulted it to "false".

Please let me know if anything is amiss. 
 
<img width="980" alt="image" src="https://user-images.githubusercontent.com/18430086/212225500-9d9baf3e-9a78-44f3-8e5e-87ecbfee9dbd.png">

<img width="359" alt="image" src="https://user-images.githubusercontent.com/18430086/212225550-5eae4a09-2a95-42b7-9c34-85da8e390b05.png">
