### PR TITLE
feat: Adding Cassandra Query Language

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -664,6 +664,12 @@ export const LANGUAGES = [
     highlight: true,
   },
   {
+    name: 'CQL',
+    mode: 'sql',
+    mime: 'text/x-cassandra',
+    short: 'cassandra',
+  },
+  {
     name: 'Clojure',
     mode: 'clojure',
     highlight: true,


### PR DESCRIPTION
## Description

I started to work a lot with Cassandra Query Language recently and I'm constantly building examples and documentations using Carbon, but I realized that is a good thing to enable it by default since [CodeMirror](https://github.dev/codemirror/codemirror5/blob/9974ded36bf01746eb2a00926916fef834d3d0d0/mode/sql/sql.js#L382-L383) already have it setup by default.

## Implemetation 

* Enabled Cassandra Query Language (CQL) support.
