### PR TITLE
fix: generated image position

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -108,13 +108,13 @@ class Editor extends React.Component {
     const width = node.offsetWidth * exportSize
     const height = squared ? node.offsetWidth * exportSize : node.offsetHeight * exportSize
 
-    const transformOrigin = window.navigator.userAgent.indexOf('Safari') !== -1 ? '0 50%' : 'center'
-
     const config = {
       style: {
         transform: `scale(${exportSize})`,
-        'transform-origin': transformOrigin,
+        transformOrigin: 'top left',
         background: squared ? this.state.backgroundColor : 'none',
+        alignItems: 'start',
+        justifyContent: 'start',
       },
       filter: n => {
         if (n.className) {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above

Expand on it in the description below (if applicable)
Attach a screenshot (if applicable)
-->
**Issue:**  Image cutoff breaks Chrome, Brave on Mac and older Safari

**Solution:** Fix the position of generated image

Safari - 16.3
<img width="1317" alt="Pasted Graphic 1" src="https://github.com/carbon-app/carbon/assets/66638216/60b30985-0856-4b51-ae2b-fe0fa4fea8a5">

Brave -  v1.52.130
<img width="1680" alt="Pasted Graphic 3" src="https://github.com/carbon-app/carbon/assets/66638216/fc894b54-0801-46ba-9f75-59815031e5a3">

Chrome - 114.0.5735.198

<img width="1672" alt="Pasted Graphic 2" src="https://github.com/carbon-app/carbon/assets/66638216/737f0b83-aff4-4686-8faa-9ddf8f268c7f">


Firefox - 115.0.2 
<img width="1277" alt="Pasted Graphic 4" src="https://github.com/carbon-app/carbon/assets/66638216/f0ae9d11-5f95-4e52-aa89-a15624a73aa3">



Closes #1474
