### PR TITLE
Add support for BNF (Backus–Naur Form)

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -640,6 +640,11 @@ export const LANGUAGES = [
     highlight: true,
   },
   {
+    name: 'BNF',
+    mode: 'bnf',
+    highlight: true,
+  },
+  {
     name: 'Plain Text',
     mode: 'text',
   },


### PR DESCRIPTION
Add BNF (Backus–Naur Form) to LANGUAGES in `lib/constants.js`. BNF is [supported](https://highlightjs.readthedocs.io/en/latest/supported-languages.html) by highlight.js.

I'm aware that new languages are not generally accepted (as per the [contributing guidelines](https://github.com/carbon-app/carbon/blob/main/.github/CONTRIBUTING.md)), but I was still hopeful that BNF could be considered a useful addition, esp. given that highlight.js already supports it.