### PR TITLE
Add support for EBNF (Extended Backus–Naur Form)

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -714,6 +714,11 @@ export const LANGUAGES = [
     highlight: true,
   },
   {
+    name: 'EBNF',
+    mode: 'ebnf',
+    highlight: true,
+  },
+  {
     name: 'Elixir',
     mode: 'elixir',
     custom: true,


### PR DESCRIPTION
Add EBNF (Extended Backus-Naur Form) to LANGUAGES in `lib/constants.js`. EBNF is [supported](https://highlightjs.readthedocs.io/en/latest/supported-languages.html) by highlight.js.

I'm aware that new languages are not generally accepted (as per the [contributing guidelines](https://github.com/carbon-app/carbon/blob/main/.github/CONTRIBUTING.md)), but I was still hopeful that EBNF could be considered a useful addition, esp. given that highlight.js already supports it.