### PR TITLE
Fix WidthHandler not following mouse position

### DIFF
--- a/components/WidthHandler.js
+++ b/components/WidthHandler.js
@@ -28,7 +28,7 @@ export default function WidthHandler({
       if (!startX.current) return
 
       const delta = e.pageX - startX.current // leftOrRight === 'left' ? startX - e.pageX : (startX - e.pageX) * -1
-      const calculated = startWidth.current + delta * window.devicePixelRatio
+      const calculated = startWidth.current + delta * window.devicePixelRatio * 2
       const newWidth = clamp(calculated, minWidth, maxWidth)
 
       onChange(newWidth)

--- a/components/WidthHandler.js
+++ b/components/WidthHandler.js
@@ -28,7 +28,7 @@ export default function WidthHandler({
       if (!startX.current) return
 
       const delta = e.pageX - startX.current // leftOrRight === 'left' ? startX - e.pageX : (startX - e.pageX) * -1
-      const calculated = startWidth.current + delta * window.devicePixelRatio * 2
+      const calculated = startWidth.current + delta * window.devicePixelRatio * (e.shiftKey ? 1 : 2)
       const newWidth = clamp(calculated, minWidth, maxWidth)
 
       onChange(newWidth)
@@ -56,6 +56,7 @@ export default function WidthHandler({
         startWidth.current = innerRef.current.clientWidth
       }}
       role="separator"
+      title="Shift + drag for 1px adjustments"
       aria-orientation="vertical"
       aria-valuemin={minWidth}
       aria-valuemax={maxWidth}


### PR DESCRIPTION
This fixes the editor edge not lining up with the mouse when adjusting the width.

Due to the editor being centered, the adjustments have to be done in increments of 2px. While 1px adjustments can be done in the settings dropdown, I have also included a fallback for the old behavior by holding `Shift` while dragging. Since this is non-obvious, I have included a brief tooltip when hovering over the width handle.