### PR TITLE
Fix image generation failure when specific characters are included

### DIFF
--- a/lib/dom-to-image.js
+++ b/lib/dom-to-image.js
@@ -346,6 +346,7 @@
           '</svg>'
         )
       })
+      .then(removeProblematicCharacters)
       .then(function (svg) {
         return 'data:image/svg+xml;charset=utf-8,' + svg
       })
@@ -463,7 +464,7 @@
           resolve(image)
         }
         image.onerror = reject
-        image.src = uri
+        image.src = removeProblematicCharacters(uri)
       })
     }
 
@@ -733,6 +734,7 @@
             return util.dataAsUrl(data, util.mimeType(element.src))
           })
           .then(function (dataUrl) {
+            dataUrl = removeProblematicCharacters(dataUrl);
             return new Promise(function (resolve, reject) {
               element.onload = resolve
               element.onerror = reject
@@ -774,5 +776,9 @@
           })
       }
     }
+  }
+
+  function removeProblematicCharacters(uri) {
+    return uri.replace(/[\u0000-\u001F\u007F-\u009F\u200B\u00A0]/g, '');
   }
 })(this)


### PR DESCRIPTION
# Summary of Changes
Resolved an issue where images were not being generated correctly when specific strings were included in the source code, as shown on the third line of the image below. This fix applies to both PNG and SVG generation.

![image](https://github.com/user-attachments/assets/7ec9207f-6f7d-46c7-905f-882056e83fc8)

# Reproduce
> reproduce url : [Carbon Code](https://carbon.now.sh/?bg=rgba%28171%2C+184%2C+195%2C+1%29&t=seti&wt=none&l=auto&width=680&ds=true&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Hack&fs=14px&lh=133%25&si=false&es=2x&wm=false&code=%252F%252F%2520Reproduce%250Apublic%2520static%2520void%2520main%28String%255B%255D%2520args%29%2520%257B%250A%2520%2520Long%2520money%2520%253D%25201000%2508L%253B%250A%257D)

```java
// Reproduce
public static void main(String[] args) {
  Long money = 1000L;
}
```

# Additional Notes
There is a known bug where typing in Korean on certain versions of macOS automatically triggers the backspace key. This issue has been documented [here](https://github.com/microsoft/vscode/issues/148356). Merging this PR will greatly benefit users experiencing this problem, including myself.