### PR TITLE
Remove obsolete Babel config for graphql-language-service-parser

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,11 +12,6 @@ module.exports = withBundleAnalyzer(
       skipWaiting: false,
     },
     webpack: (config, options) => {
-      config.module.rules.push({
-        test: /\.js$/,
-        include: /node_modules\/graphql-language-service-parser/,
-        use: [options.defaultLoaders.babel],
-      })
       config.plugins.push(
         new options.webpack.IgnorePlugin({
           resourceRegExp: /\.html$/,


### PR DESCRIPTION
Remove custom Babel configuration for graphql-language-service-parser,

which was added for old Edge browser compatibility. This is no longer

needed due to CodeMirror upgrade, simplifying the webpack config.

<!---
Provide a general summary of your changes in the Title above

Expand on it in the description below (if applicable)
Attach a screenshot (if applicable)
-->

- [ ] Integration tests (if applicable)

Closes #
